### PR TITLE
Refactor download method to be based on cURL

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,1 +1,2 @@
 ftaeger
+jeffgeorge

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,7 +5,7 @@
 
 class mailhog::install inherits mailhog {
 
-  # Add user to run mailhog with lower privilegues
+  # Add user to run mailhog with lower privileges
   user { $mailhog::user:
     ensure => 'present',
     home   => $mailhog::homedir,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,7 +17,6 @@ class mailhog::params {
   $initd_template          = 'mailhog/initd-mailhog.erb'
   $service_name            = 'mailhog'
   $config                  = '/etc/mailhog.conf'
-  $wget_cache_dir          = '/var/cache/wget'
   $download_mailhog        = true
 
   #Config values for mailhog config file

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,8 +7,8 @@
 class mailhog::params {
 
   #Config values for puppet module run
-  $mailhog_version        = '0.2.0'
-  $homedir                = '/var/lib/mailhog'
+  $mailhog_version        = '0.2.1'
+  $homedir                = '/usr/local/bin/mailhog'
   $user                   = 'mailhog'
   $service_manage          = true
   $service_enable          = true

--- a/metadata.json
+++ b/metadata.json
@@ -1,8 +1,8 @@
 {
   "name": "ftaeger-mailhog",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "author": "ftaeger",
-  "summary": "Instal & configure MailHog",
+  "summary": "Install & Configure MailHog",
   "license": "Apache-2.0",
   "source": "https://github.com/ftaeger/ftaeger-mailhog/",
   "project_page": "https://github.com/ftaeger/ftaeger-mailhog/",

--- a/metadata.json
+++ b/metadata.json
@@ -12,10 +12,6 @@
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.10.0 < 5.0.0"
     },
-    {
-      "name": "maestrodev/wget",
-      "version_requirement": ">= 1.7.4 < 2.0.0"
-    }
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
Hi @ftaeger,

My team and I were disappointed last week to see that you pulled all builds of this MailHog module from the Puppet Forge, as we've been depending on it for several months now since it's the only MailHog module I've found for Puppet.

Rather than rewriting the module from scratch to fill the void, I've updated it here to be based on cURL rather than wget which fixes issue #2, a common constant-redownloading issue with `maestrodev/wget`. I've also refactored it a tiny bit so that binaries are now downloaded to `$mailhog::homedir` and symlinked to `$mailhog::binary_file`, rather than being directly dropped into `$mailhog::binary_file`, which I've found has made it easier to switch between versions of MailHog.

I'd really appreciate it if you'd accept this PR and publish a new version 1.1.0. If you'd rather keep the project closed then I'll pursue a hard fork, publish it to Puppet Forge on my own, and take over maintenance duties.