### PR TITLE
Fix installation on i386

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -78,7 +78,7 @@ class mailhog::params {
       $download_url = "https://github.com/mailhog/MailHog/releases/download/v${mailhog_version}/MailHog_linux_arm"
       $source_file  = 'puppet:///modules/mailhog/MailHog_linux_arm'
     }
-    '386': {
+    '386', 'i386': {
       $download_url = "https://github.com/mailhog/MailHog/releases/download/v${mailhog_version}/MailHog_linux_386"
       $source_file  = 'puppet:///modules/mailhog/MailHog_linux_386'
     }


### PR DESCRIPTION
The `$::architecture` is "i386", not "386". Keep the old value for safety.