### PR TITLE
Add stubbed parameter for wget_cache_dir, resolves #8

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,7 @@ class mailhog::params {
   $service_name            = 'mailhog'
   $config                  = '/etc/mailhog.conf'
   $download_mailhog        = true
+  $wget_cache_dir          = undef
 
   #Config values for mailhog config file
   $api_bind_ip             = '0.0.0.0'


### PR DESCRIPTION
As mentioned in #8, there's an undefined variable in `init.pp` which emits a warning on newer versions of Puppet.

Rather than remove this variable, I stubbed it out in `params.pp`. It still isn't used anywhere, but at least it no longer emits a warning.